### PR TITLE
Remove funky unicode char in CH08/build.sbt

### DIFF
--- a/CH08/build.sbt
+++ b/CH08/build.sbt
@@ -50,4 +50,4 @@ val generateJOOQTask = (sourceManaged, fullClasspath in Compile, runner in Compi
 
 generateJOOQ <<= generateJOOQTask
 
- unmanagedSourceDirectories in Compile += sourceManaged.value / "main/generated"
+unmanagedSourceDirectories in Compile += sourceManaged.value / "main/generated"


### PR DESCRIPTION
NOTE: the github web diff tool does not show the character I deleted.

Running `sbt compile` in CH08, was getting the following:

```
CH08/build.sbt]:53: illegal character '\u2028'
```

Removed the character, error is gone.